### PR TITLE
Remove absolute paths from playbooks

### DIFF
--- a/step2-delete.yml
+++ b/step2-delete.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   become: true
   vars_files:
-    - /home/student/final/network_topology.yml  # Change this to your real YAML file path
+    - network_topology.yml  # Change this to your real YAML file path
 
   tasks:
 

--- a/step2.yml
+++ b/step2.yml
@@ -14,7 +14,6 @@
       name: "{{item.subnet_id}}"
       state: present
     loop: "{{network.subnets}}"
-    when: item.switch==true
 
   - debug:
       msg: "Let's see if we can make some ovs internal interfaces: "
@@ -24,7 +23,6 @@
       bridge: "{{item.subnet_id}}_sw"
       state: present
     loop: "{{network.subnets}}"
-    when: item.switch==true
 
   # - debug:
   #     msg: "Let's see if we can make some ovs internal interfaces:"

--- a/step2.yml
+++ b/step2.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   become: true
   vars_files:
-    - /home/student/final/network_topology.yml  # Change this to your real YAML file path
+    - network_topology.yml  # Change this to your real YAML file path
 
   tasks:
 


### PR DESCRIPTION
Removed absolute paths from vars_file entry in playbooks and removed contidional "when: item.swtich" lines.